### PR TITLE
Added two filters

### DIFF
--- a/vdm_metaboxes.php
+++ b/vdm_metaboxes.php
@@ -2,13 +2,14 @@
 // add events metaboxes
 function vdm_add_custom_box()
 {
-    // $screens = ['post', 'page'];
+    $screens = ['post', 'page'];
+    $screens = apply_filters( 'filter_vdm_post_types', $screens );
     foreach ($screens as $screen) {
         add_meta_box(
             'vdm_box_id',           // Unique ID
             'VoordeMensen',  // Box title
-            'vdm_custom_box_html'
-            // $screen                   // Post type
+            'vdm_custom_box_html',  // Content callback, must be of type callable
+            $screen                   // Post type
         );
     }
 }

--- a/vdm_shortcodes.php
+++ b/vdm_shortcodes.php
@@ -10,6 +10,7 @@ function vdm_shortcode_buy( $atts = [], $content = null, $tag='') {
 		$atts['button'] = 'Koop nu';
 	}
     $content = "<button onclick='javascript:vdm_order($event_id,\"".session_id()."\");'>".$atts['button']."</button>";
+	$content = apply_filters( 'vdm_buy_content', $content, $event_id, $atts );
     return $content;
 }
 


### PR DESCRIPTION
Hi,

I'd be nice if we could filter the output of the buy button shortcode. I want to integrate the shortcode in the theme with do_shortcode, so there might not always be an event selected. 
In that case we could show an alternative text. Like so:

```
add_filter( 'vdm_buy_content', function( $content, $event_id, $atts ) {
	if( empty( $event_id ) ) return 'No tickets available';
	return $content;
}, 10, 3 );

```
You were so quick with fixing the posttypes that the postype filter is no longer necessary ;)

Best, Heerko